### PR TITLE
Use gettext_lazy instead of ugettext_lazy

### DIFF
--- a/demo/backend/components/forms/date_input.py
+++ b/demo/backend/components/forms/date_input.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms_gds.fields import DateInputField
 from crispy_forms_gds.helper import FormHelper

--- a/docs/components/date.rst
+++ b/docs/components/date.rst
@@ -7,7 +7,7 @@ The `Date input`_ component allow you to enter date with separate fields for
 day, month and year: ::
 
     from django import forms
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
     from crispy_forms_gds.fields import DateInputField
     from crispy_forms_gds.helper import FormHelper

--- a/src/crispy_forms_gds/fields.py
+++ b/src/crispy_forms_gds/fields.py
@@ -3,7 +3,7 @@ from datetime import date
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms_gds.widgets import DateInputWidget
 

--- a/src/crispy_forms_gds/templatetags/crispy_forms_gds.py
+++ b/src/crispy_forms_gds/templatetags/crispy_forms_gds.py
@@ -1,7 +1,7 @@
 from django import forms, template
 from django.conf import settings
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.utils import TEMPLATE_PACK
 

--- a/src/crispy_forms_gds/widgets.py
+++ b/src/crispy_forms_gds/widgets.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class DateInputWidget(forms.MultiWidget):


### PR DESCRIPTION
Django 3.x shows a warning: `RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().`

This is because [ugettext functions are deprecated in Django 3.0] in favour of the `gettext` functions that they are aliases for.