### PR TITLE
Fix severe dependabot alerts in dev requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,138 +10,145 @@
     # via -r requirements/docs.in
 alabaster==0.7.12
     # via sphinx
-appdirs==1.4.4
-    # via
-    #   black
-    #   virtualenv
-asgiref==3.2.10
+asgiref==3.4.1
     # via django
-attrs==20.2.0
+attrs==21.2.0
     # via pytest
-babel==2.8.0
+babel==2.9.1
     # via sphinx
-black==20.8b1
-    # via pytest-black
-bleach==3.2.1
-    # via readme-renderer
-bump2version==1.0.0
-    # via -r requirements/dev.in
-certifi==2020.6.20
-    # via requests
-cffi==1.14.3
-    # via cryptography
-chardet==3.0.4
-    # via
-    #   doc8
-    #   requests
-click==7.1.2
-    # via black
-colorama==0.4.3
-    # via twine
-coverage==5.3
-    # via pytest-cov
-cryptography==3.1.1
-    # via secretstorage
-distlib==0.3.1
+backports.entry-points-selectable==1.1.0
     # via virtualenv
-django==3.1.1
+black==21.9b0
+    # via pytest-black
+bleach==4.1.0
+    # via readme-renderer
+bump2version==1.0.1
+    # via -r requirements/dev.in
+certifi==2021.5.30
+    # via requests
+cffi==1.14.6
+    # via cryptography
+charset-normalizer==2.0.6
+    # via requests
+click==8.0.1
+    # via black
+colorama==0.4.4
+    # via
+    #   sphinx-autobuild
+    #   twine
+coverage==5.5
+    # via pytest-cov
+cryptography==35.0.0
+    # via secretstorage
+distlib==0.3.3
+    # via virtualenv
+django==3.2.7
     # via crispy-forms-gds
-django-crispy-forms==1.10.0
+django-crispy-forms==1.13.0
     # via crispy-forms-gds
-doc8==0.8.1
+doc8==0.9.1
     # via -r requirements/docs.in
-docutils==0.16
+docutils==0.17.1
     # via
     #   doc8
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-filelock==3.0.12
+    #   sphinx-rtd-theme
+filelock==3.2.0
     # via
     #   tox
     #   virtualenv
-flake8==3.8.3
+flake8==3.9.2
     # via pytest-flake8
-idna==2.10
+idna==3.2
     # via requests
 imagesize==1.2.0
     # via sphinx
-iniconfig==1.0.1
+importlib-metadata==4.8.1
+    # via
+    #   keyring
+    #   twine
+iniconfig==1.1.1
     # via pytest
-isort==5.5.3
+isort==5.9.3
     # via pytest-isort
-jeepney==0.4.3
+jeepney==0.7.1
     # via
     #   keyring
     #   secretstorage
-jinja2==2.11.2
+jinja2==3.0.1
     # via sphinx
-keyring==21.4.0
+keyring==23.2.1
     # via twine
 livereload==2.6.3
     # via sphinx-autobuild
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
 mypy-extensions==0.4.3
     # via black
-packaging==20.4
+packaging==21.0
     # via
     #   bleach
     #   pytest
     #   sphinx
     #   tox
-pathspec==0.8.0
+pathspec==0.9.0
     # via black
-pbr==5.5.1
+pbr==5.6.0
     # via stevedore
-pkginfo==1.5.0.1
+pkginfo==1.7.1
     # via twine
-pluggy==0.13.1
+platformdirs==2.4.0
+    # via
+    #   black
+    #   virtualenv
+pluggy==1.0.0
     # via
     #   pytest
     #   tox
-py==1.9.0
+py==1.10.0
     # via
     #   pytest
     #   tox
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via flake8
 pycparser==2.20
     # via cffi
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via flake8
-pygments==2.7.1
+pygments==2.10.0
     # via
     #   doc8
     #   readme-renderer
     #   sphinx
 pyparsing==2.4.7
     # via packaging
-pytest==6.1.0
+pytest==6.2.5
     # via
     #   -r requirements/tests.in
     #   pytest-black
     #   pytest-cov
     #   pytest-flake8
-pytest-black==0.3.11
+pytest-black==0.3.12
     # via -r requirements/tests.in
-pytest-cov==2.10.1
+pytest-cov==2.12.1
     # via -r requirements/tests.in
-pytest-flake8==1.0.6
+pytest-flake8==1.0.7
     # via -r requirements/tests.in
-pytest-isort==1.2.0
+pytest-isort==2.0.0
     # via -r requirements/tests.in
-pytz==2020.1
+pytz==2021.1
     # via
     #   babel
     #   django
-readme-renderer==26.0
+readme-renderer==30.0
     # via twine
-regex==2020.9.27
+regex==2021.9.24
     # via black
-requests==2.24.0
+requests==2.26.0
     # via
     #   requests-toolbelt
     #   sphinx
@@ -150,72 +157,70 @@ requests-toolbelt==0.9.1
     # via twine
 restructuredtext-lint==1.3.2
     # via doc8
-rfc3986==1.4.0
+rfc3986==1.5.0
     # via twine
-secretstorage==3.1.2
+secretstorage==3.3.1
     # via keyring
-six==1.15.0
+six==1.16.0
     # via
     #   bleach
-    #   cryptography
-    #   doc8
     #   livereload
-    #   packaging
-    #   readme-renderer
     #   tox
     #   virtualenv
-snowballstemmer==2.0.0
+snowballstemmer==2.1.0
     # via sphinx
-sphinx==3.2.1
+sphinx==4.2.0
     # via
     #   -r requirements/docs.in
     #   sphinx-autobuild
     #   sphinx-rtd-theme
     #   sphinx-wildfish-theme
-sphinx-autobuild==2020.9.1
+sphinx-autobuild==2021.3.14
     # via -r requirements/docs.in
-sphinx-rtd-theme==0.5.0
+sphinx-rtd-theme==1.0.0
     # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==1.0.3
+sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.4
+sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.3.1
+sqlparse==0.4.2
     # via django
-stevedore==3.3.0
+stevedore==3.4.0
     # via doc8
-toml==0.10.1
+toml==0.10.2
     # via
-    #   black
     #   pytest
     #   pytest-black
+    #   pytest-cov
     #   tox
+tomli==1.2.1
+    # via black
 tornado==6.1
     # via livereload
-tox==3.20.0
+tox==3.24.4
     # via -r requirements/dev.in
-tqdm==4.50.0
+tqdm==4.62.3
     # via twine
-twine==3.2.0
+twine==3.4.2
     # via -r requirements/dev.in
-typed-ast==1.4.1
+typing-extensions==3.10.0.2
     # via black
-typing-extensions==3.7.4.3
-    # via black
-urllib3==1.25.10
+urllib3==1.26.7
     # via requests
-virtualenv==20.0.31
+virtualenv==20.8.1
     # via tox
 webencodings==0.5.1
     # via bleach
+zipp==3.6.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Github Dependabot raised 11 security-related alerts, mostly dev-environment related and therefore with minimal attack opportunity. Still, most of these are dealt with by this PR.