### PR TITLE
Fix for CVE-2020-24025.

### DIFF
--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -16,7 +16,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.4.2",
-    "node-sass": "^4.11.0",
+    "sass": "~1.32.0",
     "sass-loader": "^8.0.2",
     "style-loader": "^1.1.3",
     "webpack": "^4.27.1",


### PR DESCRIPTION
Improper cert validation in versions of node-sass < 7.0, but use of
version 7+ raises API incompatibility issues - it's also deprecated in
favour of dart-sass. An older version (~1.32.0) of dart-sass is
required to avoid raising division operator (/) deprecation warnings
when processing the latest version 3 line of govuk-frontend Sass.