### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @tamato will be requested for
+# review when someone opens a pull request.
+*       @uktrade/tamato


### PR DESCRIPTION
Add CODEOWNERS file to root.

It was required in order to define individuals or teams
that are responsible for code in a repository.